### PR TITLE
Fix deprecated system-pools option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Where <args>:
 Environment Variables:
   IBMCLOUD_API_KEY    IBM Cloud API key
   RELEASE_VER         OpenShift release version (Default: 4.20)
+  RHCOS_RELEASE_VER   RHCOS version (Default: 9-6)
   ARTIFACTS_VERSION   Tag or Branch name of ocp4-upi-powervs repository (Default: main)
   RHEL_SUBS_PASSWORD  RHEL subscription password if not provided in variables
   NO_OF_RETRY         Number of retries/attempts to run repeatable actions such as create (Default: 5)
@@ -192,11 +193,12 @@ Before running the script, you may choose to override some environment variables
 
 This [link](https://access.redhat.com/articles/6907891) shows the mapping of versions between OCP, RHCOS and RHEL. Note that the RHCOS versions are now aligned with RHEL version and not with OCP versions. For example, for OCP 4.20, RHCOS version is 9-6 and RHEL version is 9.6
 
-By default OpenShift version 4.20 is installed.
+By default OpenShift version 4.20 and RHCOS version 9-6 is installed.
 
-If you want to install 4.19, then export the variable `RELEASE_VER`.
+If you want to install OpenShift version 4.19, then export the variables `RELEASE_VER` and `RHCOS_RELEASE_VER` to their respective versions. Note that RHCOS version for OCP 4.19 is also 9-6.
 ```
 $ export RELEASE_VER="4.19"
+$ export RHCOS_RELEASE_VER="9-6"
 ```
 
 ### Non-interactive mode
@@ -212,8 +214,8 @@ You can avoid the interactive mode by having the required input files available 
     ibmcloud_region = "syd"
     ibmcloud_zone = "syd04"
     service_instance_id = "123456abc-xzz-2223434343"
-    rhel_image_name = "rhel-83"
-    rhcos_image_name = "rhcos-415"
+    rhel_image_name = "RHEL9-SP6"
+    rhcos_image_name = "rhcos-9-6-20250523-0-ppc64le-powervs"
     network_name = "ocp-net"
     openshift_install_tarball = "https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/stable-4.20/openshift-install-linux.tar.gz"
     openshift_client_tarball = "https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/stable-4.20/openshift-client-linux.tar.gz"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Where <args>:
 
 Environment Variables:
   IBMCLOUD_API_KEY    IBM Cloud API key
-  RELEASE_VER         OpenShift release version (Default: 4.15)
+  RELEASE_VER         OpenShift release version (Default: 4.20)
   ARTIFACTS_VERSION   Tag or Branch name of ocp4-upi-powervs repository (Default: main)
   RHEL_SUBS_PASSWORD  RHEL subscription password if not provided in variables
   NO_OF_RETRY         Number of retries/attempts to run repeatable actions such as create (Default: 5)
@@ -158,7 +158,7 @@ You'll need to place the file in the install directory and name it as **pull-sec
 
 ## Quickstart
 
-1. Export the IBM Cloud API Key and RHEL Subscription Password.
+1. Export the IBM Cloud API Key and RHEL Subscription Password. Export RHEL_SUBS_PASSWORD only if your bastion server is based on RHEL.
     ```
     $ set +o history
     $ export IBMCLOUD_API_KEY='<your API key>'
@@ -190,12 +190,13 @@ Before running the script, you may choose to override some environment variables
 
 ### Different OpenShift Versions
 
+This [link](https://access.redhat.com/articles/6907891) shows the mapping of versions between OCP, RHCOS and RHEL. Note that the RHCOS versions are now aligned with RHEL version and not with OCP versions. For example, for OCP 4.20, RHCOS version is 9-6 and RHEL version is 9.6
 
-By default OpenShift version 4.15 is installed.
+By default OpenShift version 4.20 is installed.
 
-If you want to install 4.14, then export the variable `RELEASE_VER`.
+If you want to install 4.19, then export the variable `RELEASE_VER`.
 ```
-$ export RELEASE_VER="4.14"
+$ export RELEASE_VER="4.19"
 ```
 
 ### Non-interactive mode
@@ -214,8 +215,8 @@ You can avoid the interactive mode by having the required input files available 
     rhel_image_name = "rhel-83"
     rhcos_image_name = "rhcos-415"
     network_name = "ocp-net"
-    openshift_install_tarball = "https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/stable-4.15/openshift-install-linux.tar.gz"
-    openshift_client_tarball = "https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/stable-4.15/openshift-client-linux.tar.gz"
+    openshift_install_tarball = "https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/stable-4.20/openshift-install-linux.tar.gz"
+    openshift_client_tarball = "https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/stable-4.20/openshift-client-linux.tar.gz"
     cluster_id_prefix = "test-ocp"
     cluster_domain = "xip.io"
     storage_type = "nfs"

--- a/openshift-install-powervs
+++ b/openshift-install-powervs
@@ -49,8 +49,8 @@ Where <args>:
 
 Environment Variables:
   IBMCLOUD_API_KEY    IBM Cloud API key
-  RELEASE_VER         OpenShift release version (Default: 4.15)
-  RHCOS_RELEASE_VER   RHCOS Release version (Default: 9.4)
+  RELEASE_VER         OpenShift release version (Default: 4.20)
+  RHCOS_RELEASE_VER   RHCOS Release version (Default: 9-6)
   ARTIFACTS_VERSION   Tag or Branch name of ocp4-upi-powervs repository (Default: main)
   RHEL_SUBS_PASSWORD  RHEL subscription password if not provided in variables
   NO_OF_RETRY         Number of retries/attempts to run repeatable actions such as create (Default: 5)
@@ -61,8 +61,8 @@ EOF
   exit 0
 }
 
-RELEASE_VER=${RELEASE_VER:-"4.15"}
-RHCOS_RELEASE_VER=${RHCOS_RELEASE_VER:-"9.4"}
+RELEASE_VER=${RELEASE_VER:-"4.20"}
+RHCOS_RELEASE_VER=${RHCOS_RELEASE_VER:-"9-6"}
 ARTIFACTS_REPO=${ARTIFACTS_REPO:-"https://github.com/ocp-power-automation/ocp4-upi-powervs"}
 ARTIFACTS_VERSION=${ARTIFACTS_VERSION:-"main"}
 #ARTIFACTS_VERSION=${ARTIFACTS_VERSION:-"release-$RELEASE_VER"}

--- a/openshift-install-powervs
+++ b/openshift-install-powervs
@@ -1051,7 +1051,7 @@ function variables {
 
   [ -z "$ALL_OCP_VERSIONS" ] && error "No OCP versions found for version $RELEASE_VER... Ensure you have set correct RELEASE_VER"
 
-  ALL_SYSTEM_TYPES=$($CLI_PATH pi datacenter get ${ZONE} 2>/dev/null | grep "General" |cut -f2 -d\[ | cut -f1 -d\] | sort |sed 's/ /\n/g')
+  ALL_SYSTEM_TYPES=$($CLI_PATH pi datacenter get ${ZONE} 2>/dev/null | grep "General" |cut -f2 -d\[ | cut -f1 -d\] | tr ' ' '\n' | sort -V)
   [ -z "$ALL_SYSTEM_TYPES" ] && error "Cannot find available System Types... please try again"
 
   # TODO: Get region from a map of `zone:region` or any other good way

--- a/openshift-install-powervs
+++ b/openshift-install-powervs
@@ -50,6 +50,7 @@ Where <args>:
 Environment Variables:
   IBMCLOUD_API_KEY    IBM Cloud API key
   RELEASE_VER         OpenShift release version (Default: 4.15)
+  RHCOS_RELEASE_VER   RHCOS Release version (Default: 9.4)
   ARTIFACTS_VERSION   Tag or Branch name of ocp4-upi-powervs repository (Default: main)
   RHEL_SUBS_PASSWORD  RHEL subscription password if not provided in variables
   NO_OF_RETRY         Number of retries/attempts to run repeatable actions such as create (Default: 5)
@@ -61,6 +62,7 @@ EOF
 }
 
 RELEASE_VER=${RELEASE_VER:-"4.15"}
+RHCOS_RELEASE_VER=${RHCOS_RELEASE_VER:-"9.4"}
 ARTIFACTS_REPO=${ARTIFACTS_REPO:-"https://github.com/ocp-power-automation/ocp4-upi-powervs"}
 ARTIFACTS_VERSION=${ARTIFACTS_VERSION:-"main"}
 #ARTIFACTS_VERSION=${ARTIFACTS_VERSION:-"release-$RELEASE_VER"}
@@ -1028,7 +1030,7 @@ function variables {
     CATALOG_RHEL_IMAGES=$($CLI_PATH pi image lc --json | grep name | grep -iE 'rhel|centos' | cut -f4 -d\")
     BOOT_IMAGES=$($CLI_PATH pi image ls --json | grep name | grep -vi rhcos | cut -f4 -d\")
     RHEL_IMAGES="${CATALOG_RHEL_IMAGES}${IFS}${BOOT_IMAGES}"
-    RHCOS_IMAGES=$($CLI_PATH pi image ls --json | grep name | grep -vi rhel | grep -vi centos | grep -i "rhcos-${RELEASE_VER//.}-" | cut -f4 -d\")
+    RHCOS_IMAGES=$($CLI_PATH pi image ls --json | grep name | grep -vi rhel | grep -vi centos | grep -i "rhcos-${RHCOS_RELEASE_VER//.}-" | cut -f4 -d\")
     [[ -z $RHCOS_IMAGES ]] && error "Cannot find RHCOS image for OCP $RELEASE_VER! Please use option '-all-images' if you have already imported the image"
   fi
 
@@ -1049,7 +1051,7 @@ function variables {
 
   [ -z "$ALL_OCP_VERSIONS" ] && error "No OCP versions found for version $RELEASE_VER... Ensure you have set correct RELEASE_VER"
 
-  ALL_SYSTEM_TYPES=$($CLI_PATH pi system-pools 2>/dev/null | grep "System Type" | awk '{print $3}' | sort | uniq)
+  ALL_SYSTEM_TYPES=$($CLI_PATH pi datacenter get ${ZONE} 2>/dev/null | grep "General" |cut -f2 -d\[ | cut -f1 -d\] | sort |sed 's/ /\n/g')
   [ -z "$ALL_SYSTEM_TYPES" ] && error "Cannot find available System Types... please try again"
 
   # TODO: Get region from a map of `zone:region` or any other good way


### PR DESCRIPTION
"ibmcloud pi system-pools" command is deprecated now. Use "ibmcloud pi datacenter" command.
Also RHCOS image versioning has changed. Instead of mapping to OCP versions, now RHCOS images are mapped to RHEL version. So, I made this change too in the script.