### PR TITLE
Avoid downloading ibmcloud cli every time

### DIFF
--- a/openshift-install-powervs
+++ b/openshift-install-powervs
@@ -1273,9 +1273,9 @@ function setup_ibmcloudcli() {
 
   EXT_PATH=$(which ibmcloud 2> /dev/null || true)
 
-  if [[ -f $CLI_PATH && $($CLI_PATH -v | sed 's/.*version //' | sed 's/+.*//') == "${CLI_LATEST}" ]]; then
+  if [[ -f $CLI_PATH && $($CLI_PATH -v | head -n1 | awk '{print $2}') == "${CLI_LATEST}" ]]; then
     return
-  elif [[ -n "$EXT_PATH" && $($EXT_PATH -v | sed 's/.*version //' | sed 's/+.*//') == "${CLI_LATEST}" ]] ; then
+  elif [[ -n "$EXT_PATH" && $($EXT_PATH -v | head -n1 | awk '{print $2}') == "${CLI_LATEST}" ]] ; then
     CLI_PATH="$EXT_PATH"
     return
   else


### PR DESCRIPTION
Fixes #238 

```
yussufshaikh@Yussufs-MacBook-Pro openshift-install-power % ./openshift-install-powervs output
╷
│ Warning: No outputs found
│
│ The state file either has no outputs defined, or all the defined outputs are empty. Please define an output in your configuration with the `output` keyword and run `terraform refresh` for it to become available. If you are using
│ interpolation, please verify the interpolated value is not empty. You can use the `terraform console` command to assist.
╵
yussufshaikh@Yussufs-MacBook-Pro openshift-install-power % ./openshift-install-powervs output
╷
│ Warning: No outputs found
│
│ The state file either has no outputs defined, or all the defined outputs are empty. Please define an output in your configuration with the `output` keyword and run `terraform refresh` for it to become available. If you are using
│ interpolation, please verify the interpolated value is not empty. You can use the `terraform console` command to assist.
╵
yussufshaikh@Yussufs-MacBook-Pro openshift-install-power %
```