### PR TITLE
fix: add arm64/aarch64 support and RHEL 9/10 OS version checks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "devel"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -226,6 +226,20 @@ You can avoid the interactive mode by having the required input files available 
     You can also use the option `-var "key=value"` to pass a single variable.
     If the same variable is given more than once then precedence will be from left (low) to right (high).
 
+## Post Install
+It is important to finish the configutation at Cloud Internet Services(CIS),  before the openshift installation you should have delegated your custom domain (anyname.xyz) to CIS by pointing CIS's NameServers in your domain registrant. Even if domain shows active there are still missing some records from Bastion's public IP to the console, oath and api server, follow these steps to complete the powervs bastion node being able to resolve a custom domain.
+
+1. Go to your CIS instance -->Reliability--->DNS--->DNS records
+2. Click Add
+   Type : A
+   TTL: Automatic
+   name:  console-openshift.apps.test.yourclustername.   (do not add your domain at the end, is automatically appended with the record)
+   IPv4 address: xx.xx.xx.xx  (your Bastion's public IP address)
+   Add
+
+Repeat the same for: api.yourclustername ,  *.apps.yourclustername, same public IP for all 3 records.
+
+After the records are added console link should start resolving correctly.
 ## Tutorials
 
 Check out the following [learning path](https://developer.ibm.com/series/deploy-ocp-cloud-paks-power-virtual-server/) for deploying and using OpenShift on PowerVS

--- a/README.md
+++ b/README.md
@@ -227,19 +227,67 @@ You can avoid the interactive mode by having the required input files available 
     If the same variable is given more than once then precedence will be from left (low) to right (high).
 
 ## Post Install
-It is important to finish the configutation at Cloud Internet Services(CIS),  before the openshift installation you should have delegated your custom domain (anyname.xyz) to CIS by pointing CIS's NameServers in your domain registrant. Even if domain shows active there are still missing some records from Bastion's public IP to the console, oath and api server, follow these steps to complete the powervs bastion node being able to resolve a custom domain.
+Before installing OpenShift, you should delegate your custom domain (for example, anyname.xyz) to IBM Cloud Internet Services (CIS) by updating your domain registrar to use the CIS-provided authoritative name servers.
 
-1. Go to your CIS instance -->Reliability--->DNS--->DNS records
-2. Click Add
-   Type : A
-   TTL: Automatic
-   name:  console-openshift.apps.test.yourclustername.   (do not add your domain at the end, is automatically appended with the record)
-   IPv4 address: xx.xx.xx.xx  (your Bastion's public IP address)
-   Add
+Although the domain may appear as Active in CIS, the DNS records required by OpenShift are not created automatically. You must manually create DNS records that map your PowerVS Bastion public IP address to the OpenShift API and application endpoints.
 
-Repeat the same for: api.yourclustername ,  *.apps.yourclustername, same public IP for all 3 records.
+Follow the steps below to configure DNS resolution for your OpenShift cluster.
 
-After the records are added console link should start resolving correctly.
+Create DNS Records in CIS
+1. Open your Cloud Internet Services (CIS) instance.
+2. Navigate to Reliability → DNS → DNS Records.
+3. Click Add Record.
+4. Create the following DNS entries, all pointing to the Bastion public IP address.
+**Openshift Console Route**
+```
+Type: A
+TTL: Automatic
+Name: console-openshift-console.apps.test.<cluster-name>
+IPv4 Address: <bastion-public-ip>
+```
+Note: Do not append your domain name (anyname.xyz) to the record name. CIS automatically appends the zone name.
+**Openshift API Endpoint**
+```
+Type: A
+TTL: Automatic
+Name: api.test.<cluster-name>
+IPv4 Address: <bastion-public-ip>
+```
+**Openshift Applications Wildcard Route**
+```
+Type: A
+TTL: Automatic
+Name: *.apps.test.<cluster-name>
+IPv4 Address: <bastion-public-ip>
+```
+**Example**
+For a cluster named test-ocp-9652 in the domain ocptest.xyz with a Bastion public IP of 67.18.71.69, create:
+```
+console-openshift-console.apps.test-ocp-9652 -> 67.18.71.69
+api.test-ocp-9652                            -> 67.18.71.69
+*.apps.test-ocp-9652                         -> 67.18.71.69
+```
+The resulting FQDNs will be:
+```
+console-openshift-console.apps.test-ocp-9652.ocptest.xyz
+api.test-ocp-9652.ocptest.xyz
+*.apps.test-ocp-9652.ocptest.xyz
+```
+**Validation**
+Verify that the records resolve correctly:
+```
+nslookup console-openshift-console.apps.test-ocp-9652.ocptest.xyz
+nslookup api.test-ocp-9652.ocptest.xyz
+```
+Verify access to the Openshift Console:
+```
+curl -kI https://console-openshift-console.apps.test-ocp-9652.ocptest.xyz
+```
+A successful response should return:
+```
+HTTP/1.1 200 OK
+```
+
 ## Tutorials
 
 Check out the following [learning path](https://developer.ibm.com/series/deploy-ocp-cloud-paks-power-virtual-server/) for deploying and using OpenShift on PowerVS

--- a/openshift-install-powervs
+++ b/openshift-install-powervs
@@ -1229,6 +1229,10 @@ function setup_terraform {
     log "Installing the latest version of Terraform..."
     if [[ "${ARCH}" == "ppc64le" ]]; then
       retry "curl --connect-timeout 30 -fsSL https://github.com/ppc64le-development/terraform-ppc64le/releases/download/${TF_LATEST}/terraform-${TF_LATEST} -o ${TF}"
+    elif [[ "${ARCH}" == "arm64" ]]; then
+      retry "curl --connect-timeout 30 -fsSL https://releases.hashicorp.com/terraform/${TF_LATEST:1}/terraform_${TF_LATEST:1}_${OS}_arm64.zip -o ./terraform.zip"
+      unzip -o ./terraform.zip  >/dev/null 2>&1
+      rm -f ./terraform.zip
     else
       retry "curl --connect-timeout 30 -fsSL https://releases.hashicorp.com/terraform/${TF_LATEST:1}/terraform_${TF_LATEST:1}_${OS}_amd64.zip -o ./terraform.zip"
       unzip -o ./terraform.zip  >/dev/null 2>&1
@@ -1302,10 +1306,13 @@ function setup_ibmcloudcli() {
 #-------------------------------------------------------------------------
 function setup_occli() {
 
-  OC_BASE_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/stable-${RELEASE_VER}"
+  OC_ARCH="${ARCH}"
+  [[ "${ARCH}" == "arm64" ]] && OC_ARCH="aarch64"
+
+  OC_BASE_URL="https://mirror.openshift.com/pub/openshift-v4/${OC_ARCH}/clients/ocp/stable-${RELEASE_VER}"
   OC_DOWNLOAD_URL="${OC_BASE_URL}/openshift-client-${OC_CLI_OS}.${ARCHIVE_TYPE}"
 
-  OC_DEV_BASE_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp-dev-preview/latest-${RELEASE_VER}"
+  OC_DEV_BASE_URL="https://mirror.openshift.com/pub/openshift-v4/${OC_ARCH}/clients/ocp-dev-preview/latest-${RELEASE_VER}"
   OC_DEV_DOWNLOAD_URL="${OC_DEV_BASE_URL}/openshift-client-${OC_CLI_OS}.${ARCHIVE_TYPE}"
 
   EXT_PATH=$(which oc 2> /dev/null || true)
@@ -1552,6 +1559,7 @@ function validate_flavor {
 #-------------------------------------------------------------------------
 function platform_checks {
   ARCH=$(uname -m)
+  [[ "${ARCH}" == "aarch64" ]] && ARCH="arm64"
   if [[ "${ARCH}" != "x86_64" ]] && [[ "${ARCH}" != "ppc64le" ]] && [[ "${ARCH}" != "arm64" ]]; then
     warn "Only 64-bit x86 and Power machines are supported"
     error "Unsupported machine: ${ARCH}" 1
@@ -1576,7 +1584,7 @@ function platform_checks {
       if [[ $IGNORE_OS -eq 0 ]] && [[ "$DISTRO" != *Ubuntu* && "$DISTRO" != *Red*Hat* && "$DISTRO" != *CentOS* ]]; then
         error "Unsupported Linux distribution"
       fi
-      if [[ $IGNORE_OS -eq 0 ]] && [[ $OS_VERSION != "16.04" && $OS_VERSION != "18.04" && $OS_VERSION != "20.04" && $OS_VERSION != "22.04" && $OS_VERSION != "24.04" && $OS_VERSION != "8"* ]]; then
+      if [[ $IGNORE_OS -eq 0 ]] && [[ $OS_VERSION != "16.04" && $OS_VERSION != "18.04" && $OS_VERSION != "20.04" && $OS_VERSION != "22.04" && $OS_VERSION != "24.04" && $OS_VERSION != "8"* && $OS_VERSION != "9"* && $OS_VERSION != "10"* ]]; then
         error "Unsupported OS version ($OS_VERSION) for $DISTRO"
       fi
       if [[ "$DISTRO" == *Ubuntu* || "$DISTRO" == *Debian*  ]]; then
@@ -1589,6 +1597,8 @@ function platform_checks {
       OS="linux"
       if [[ "$ARCH" == "ppc64le" ]]; then
         IBM_CLI_OS="linux_ppc64le"
+      elif [[ "$ARCH" == "arm64" ]]; then
+        IBM_CLI_OS="linux_arm64"
       else
         IBM_CLI_OS="linux_amd64"
       fi

--- a/var.tfvars
+++ b/var.tfvars
@@ -1,0 +1,24 @@
+ibmcloud_region = "dal"
+ibmcloud_zone = "dal14"
+service_instance_id = "workspace-id"
+rhel_image_name =  "RHEL9-SP6"
+rhcos_image_name =  "rhcos-9-6-20260619-0-ppc64le"
+system_type =  "s1122"
+network_name =  "ocp-bgp-subnet"
+openshift_install_tarball =  "https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest-4.20/openshift-install-linux.tar.gz"
+openshift_client_tarball =  "https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest-4.20/openshift-client-linux.tar.gz"
+cluster_id_prefix = "test-ocp"
+cluster_domain = "ocptest.xyz"
+## Medium Configuration Template
+
+bastion   = { memory = "16", processors = "1", "count" = 1 }
+bootstrap = { memory = "32", processors = "0.5", "count" = 1 }
+master    = { memory = "32", processors = "0.5", "count" = 3 }
+worker    = { memory = "32", processors = "0.5", "count" = 3 }
+
+storage_type = "none"
+rhel_subscription_username = "mgomezmx2"
+rhel_subscription_password = ""
+pull_secret_file = "/root/ocp-install-dir2/pull-secret.txt"
+private_key_file = "/root/ocp-install-dir2/id_rsa"
+public_key_file = "/root/ocp-install-dir2/id_rsa.pub"


### PR DESCRIPTION
- Normalize aarch64 to arm64 in platform_checks
- Download correct arm64 Terraform binary
- Set IBM CLI OS to linux_arm64 for arm64
- Map arm64 to aarch64 for OpenShift mirror URLs
- Add RHEL 9* and 10* to supported OS version list